### PR TITLE
Add support for hotspot-hotspot edge keys

### DIFF
--- a/src/cmd/manifest.rs
+++ b/src/cmd/manifest.rs
@@ -68,7 +68,7 @@ impl Generate {
         let mut manifest_file = open_output_file(&self.manifest, !self.force)?;
         let manifest = Manifest {
             serial: self.serial,
-            hash: base64::encode(&filter_hash),
+            hash: base64::encode(filter_hash),
             signatures,
         };
         serde_json::to_writer_pretty(&mut manifest_file, &manifest)?;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -158,6 +158,6 @@ mod base64 {
         if data.is_empty() {
             return s.serialize_str("");
         }
-        s.serialize_str(&base64::encode(&data))
+        s.serialize_str(&base64::encode(data))
     }
 }


### PR DESCRIPTION
Edge keys represent the connection between two hotspots. The direction of the edge is not important, so the keys are lexiographically sorted before being xxhash64 hashed.