### PR TITLE
Use descriptor to hold deny list 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "ff"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +463,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +505,17 @@ checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
  "digest 0.9.0",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -1130,6 +1153,7 @@ dependencies = [
  "clap",
  "csv",
  "helium-crypto",
+ "indexmap",
  "rand",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ serde_json = "1"
 rand = "0.8"
 helium-crypto = { version = "0.8.0", features = ["multisig"] }
 anyhow = "1"
+indexmap = { version = "2", features = ["serde"] }

--- a/src/cmd/descriptor.rs
+++ b/src/cmd/descriptor.rs
@@ -1,0 +1,47 @@
+use crate::{cmd::open_output_file, Descriptor, Result};
+use std::path::PathBuf;
+
+#[derive(clap::Args, Debug)]
+pub struct Cmd {
+    #[command(subcommand)]
+    pub cmd: DescriptorCommand,
+}
+
+impl Cmd {
+    pub fn run(&self) -> Result {
+        self.cmd.run()
+    }
+}
+
+/// Commands on filters
+#[derive(clap::Subcommand, Debug)]
+pub enum DescriptorCommand {
+    Generate(Generate),
+}
+
+impl DescriptorCommand {
+    pub fn run(&self) -> Result {
+        match self {
+            Self::Generate(cmd) => cmd.run(),
+        }
+    }
+}
+
+/// Generate a descriptor file for the given csv file
+#[derive(Debug, clap::Args)]
+pub struct Generate {
+    /// The input csv file to generate a descriptor for
+    input: PathBuf,
+    /// The file to write the resulting descriptor file to
+    #[arg(default_value = "descriptor.json")]
+    output: PathBuf,
+}
+
+impl Generate {
+    pub fn run(&self) -> Result {
+        let descriptor = Descriptor::from_csv(&self.input)?;
+        let file = open_output_file(&self.output, false)?;
+        serde_json::to_writer(file, &descriptor)?;
+        Ok(())
+    }
+}

--- a/src/cmd/filter.rs
+++ b/src/cmd/filter.rs
@@ -116,7 +116,7 @@ impl Generate {
         let key_manifest = PublicKeyManifest::from_path(&self.key)?;
         let key = key_manifest.public_key()?;
 
-        let descriptor = Descriptor::from_csv(&self.input)?;
+        let descriptor = Descriptor::from_json(&self.input)?;
         let mut filter = Filter::from_descriptor(manifest.serial, &descriptor)?;
         filter.signature = manifest.sign(&key_manifest)?;
         let filter_bytes = filter.to_bytes()?;

--- a/src/cmd/filter.rs
+++ b/src/cmd/filter.rs
@@ -37,7 +37,7 @@ impl FilterCommand {
     }
 }
 
-/// Check if a given filter file contains a given public key
+/// Check if a given filter file contains a given public key or edge.
 #[derive(clap::Args, Debug)]
 pub struct Contains {
     /// The input file to generate a filter for
@@ -45,14 +45,21 @@ pub struct Contains {
     input: PathBuf,
     /// The public key to check
     key: PublicKey,
+    /// The publc key of the target of an edge to check
+    target: Option<PublicKey>,
 }
 
 impl Contains {
     pub fn run(&self) -> Result {
         let filter = Filter::from_path(&self.input)?;
+        let in_filter = if let Some(target) = &self.target {
+            filter.contains_edge(&self.key, target)
+        } else {
+            filter.contains(&self.key)
+        };
         let json = json!({
             "address":  self.key.to_string(),
-            "in_filter": filter.contains(&self.key),
+            "in_filter": in_filter,
         });
         print_json(&json)
     }

--- a/src/cmd/filter.rs
+++ b/src/cmd/filter.rs
@@ -1,6 +1,6 @@
 use crate::{
     cmd::{open_output_file, print_json},
-    Filter, Manifest, PublicKeyManifest, Result,
+    Descriptor, Filter, Manifest, PublicKeyManifest, Result,
 };
 use anyhow::bail;
 use helium_crypto::PublicKey;
@@ -87,8 +87,8 @@ impl Verify {
 /// and the signature included in the resulting output.
 #[derive(Debug, clap::Args)]
 pub struct Generate {
-    /// The input csv file to generate a filter for
-    #[arg(long, short)]
+    /// The input descriptor file to generate a filter for
+    #[arg(long, short, default_value = "descriptor.json")]
     input: PathBuf,
     /// The public key file to use
     #[arg(long, short, default_value = "public_key.json")]
@@ -109,7 +109,8 @@ impl Generate {
         let key_manifest = PublicKeyManifest::from_path(&self.key)?;
         let key = key_manifest.public_key()?;
 
-        let mut filter = Filter::from_csv(manifest.serial, &self.input)?;
+        let descriptor = Descriptor::from_csv(&self.input)?;
+        let mut filter = Filter::from_descriptor(manifest.serial, &descriptor)?;
         filter.signature = manifest.sign(&key_manifest)?;
         let filter_bytes = filter.to_bytes()?;
         let mut file = open_output_file(&self.output, false)?;

--- a/src/cmd/manifest.rs
+++ b/src/cmd/manifest.rs
@@ -68,7 +68,7 @@ pub struct Generate {
 
 impl Generate {
     pub fn run(&self) -> Result {
-        let descriptor = Descriptor::from_csv(&self.input)?;
+        let descriptor = Descriptor::from_json(&self.input)?;
         let filter = Filter::from_descriptor(self.serial, &descriptor)?;
         let filter_hash = filter.hash()?;
         let key_manifest = PublicKeyManifest::from_path(&self.key)?;
@@ -115,7 +115,7 @@ impl Verify {
         let manifest = Manifest::from_path(&self.manifest)?;
         let manifest_hash = STANDARD.decode(&manifest.hash)?;
 
-        let descriptor = Descriptor::from_csv(&self.input)?;
+        let descriptor = Descriptor::from_json(&self.input)?;
         let filter = Filter::from_descriptor(manifest.serial, &descriptor)?;
         let filter_hash = filter.hash()?;
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,5 +1,6 @@
 use std::{fs, io, path::Path};
 
+pub mod descriptor;
 pub mod filter;
 pub mod key;
 pub mod manifest;

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -18,15 +18,15 @@ pub struct Edges {
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct Edge {
-    source: u32,
-    target: u32,
-    reason: Option<String>,
+    pub source: u32,
+    pub target: u32,
+    pub reason: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Eq)]
 pub struct Node {
-    key: PublicKey,
-    reason: Option<String>,
+    pub key: PublicKey,
+    pub reason: Option<String>,
 }
 
 impl PartialEq for Node {

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -1,0 +1,159 @@
+use crate::Result;
+use helium_crypto::PublicKey;
+use indexmap::IndexSet;
+use serde::{Deserialize, Serialize};
+use std::{fs::File, path::Path};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Descriptor {
+    pub nodes: IndexSet<Node>,
+    pub edges: Edges,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Edges {
+    pub keys: IndexSet<PublicKey>,
+    pub edges: Vec<Edge>,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct Edge {
+    source: u32,
+    target: u32,
+    reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Eq)]
+pub struct Node {
+    key: PublicKey,
+    reason: Option<String>,
+}
+
+impl PartialEq for Node {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key
+    }
+}
+
+impl std::hash::Hash for Node {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.key.hash(state);
+    }
+}
+
+impl PartialOrd for Node {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.key.partial_cmp(&other.key)
+    }
+}
+
+impl Ord for Node {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.key.cmp(&other.key)
+    }
+}
+
+//
+// Private
+//
+#[derive(Debug, Deserialize)]
+struct CsvRow {
+    pub public_key: PublicKey,
+    pub target_key: Option<PublicKey>,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Eq)]
+struct EdgeNode {
+    source: PublicKey,
+    target: PublicKey,
+    reason: Option<String>,
+}
+
+impl std::hash::Hash for EdgeNode {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.source.hash(state);
+        self.target.hash(state);
+    }
+}
+
+impl PartialEq for EdgeNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.source == other.source && self.target == other.target
+    }
+}
+
+impl PartialOrd for EdgeNode {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.source.partial_cmp(&other.source)
+    }
+}
+
+impl Ord for EdgeNode {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.source.cmp(&other.source)
+    }
+}
+
+impl EdgeNode {
+    pub fn new(source: PublicKey, target: PublicKey, reason: Option<String>) -> Self {
+        Self {
+            source,
+            target,
+            reason,
+        }
+    }
+}
+
+impl Descriptor {
+    pub fn from_csv(path: &Path) -> Result<Self> {
+        let mut rdr = csv::ReaderBuilder::new()
+            .has_headers(false)
+            .from_reader(File::open(path)?);
+        let mut nodes = IndexSet::new();
+        let mut edge_nodes: IndexSet<EdgeNode> = IndexSet::new();
+        let mut edge_keys: IndexSet<PublicKey> = IndexSet::new();
+
+        for record in rdr.deserialize() {
+            let row: CsvRow = record?;
+            if let Some(target_key) = row.target_key {
+                // edge key order needs to be sorted to be deterministic
+                // irregardless of edge direction
+                let mut a = [row.public_key, target_key];
+                a.sort();
+                let edge = EdgeNode::new(a[0].clone(), a[1].clone(), row.reason);
+                edge_keys.insert(edge.source.clone());
+                edge_keys.insert(edge.target.clone());
+                edge_nodes.insert(edge);
+            } else {
+                nodes.insert(Node {
+                    key: row.public_key,
+                    reason: row.reason,
+                });
+            }
+        }
+
+        nodes.sort_unstable();
+        edge_nodes.sort_unstable();
+        let edges = edge_nodes
+            .into_iter()
+            .map(|node| {
+                let source = edge_keys.get_index_of(&node.source).unwrap() as u32;
+                let target = edge_keys.get_index_of(&node.target).unwrap() as u32;
+                Edge {
+                    source,
+                    target,
+                    reason: node.reason,
+                }
+            })
+            .collect();
+
+        Ok(Self {
+            nodes,
+            edges: Edges {
+                keys: edge_keys,
+                edges,
+            },
+        })
+    }
+}

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -106,6 +106,12 @@ impl EdgeNode {
 }
 
 impl Descriptor {
+    pub fn from_json(path: &Path) -> Result<Self> {
+        let file = File::open(path)?;
+        let descriptor = serde_json::from_reader(file)?;
+        Ok(descriptor)
+    }
+
     pub fn from_csv(path: &Path) -> Result<Self> {
         let mut rdr = csv::ReaderBuilder::new()
             .has_headers(false)

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -1,4 +1,4 @@
-use crate::Result;
+use crate::{filter::edge_order, Result};
 use helium_crypto::PublicKey;
 use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
@@ -123,11 +123,9 @@ impl Descriptor {
         for record in rdr.deserialize() {
             let row: CsvRow = record?;
             if let Some(target_key) = row.target_key {
-                // edge key order needs to be sorted to be deterministic
-                // irregardless of edge direction
-                let mut a = [row.public_key, target_key];
-                a.sort();
-                let edge = EdgeNode::new(a[0].clone(), a[1].clone(), row.reason);
+                // we enforce edge order here to dedupe two way edges.
+                let (source, target) = edge_order(&row.public_key, &target_key);
+                let edge = EdgeNode::new(source.clone(), target.clone(), row.reason);
                 edge_keys.insert(edge.source.clone());
                 edge_keys.insert(edge.target.clone());
                 edge_nodes.insert(edge);

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -28,7 +28,7 @@ impl Filter {
         })
     }
 
-    pub fn from_csv<P: AsRef<Path>>(serial: u32, path: P) -> Result<Self> {
+    pub fn from_csv(serial: u32, path: &Path) -> Result<Self> {
         let mut rdr = csv::ReaderBuilder::new()
             .has_headers(false)
             .from_reader(File::open(path)?);

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -111,7 +111,16 @@ fn public_key_hash(public_key: &PublicKey) -> u64 {
     hasher.finish()
 }
 
-fn edge_hash(a: &PublicKey, b: &PublicKey) -> u64 {
+pub(crate) fn edge_order<'a>(a: &'a PublicKey, b: &'a PublicKey) -> (&'a PublicKey, &'a PublicKey) {
+    if a < b {
+        (a, b)
+    } else {
+        (b, a)
+    }
+}
+
+pub(crate) fn edge_hash(a: &PublicKey, b: &PublicKey) -> u64 {
+    let (a, b) = edge_order(a, b);
     let mut hasher = XxHash64::default();
     hasher.write(&a.to_vec());
     hasher.write(&b.to_vec());

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -62,6 +62,10 @@ impl Filter {
         self.filter.contains(&public_key_hash(public_key))
     }
 
+    pub fn contains_edge(&self, source: &PublicKey, target: &PublicKey) -> bool {
+        self.filter.contains(&edge_hash(source, target))
+    }
+
     pub fn verify(&self, public_key: &PublicKey) -> Result {
         let msg = self.signing_bytes()?;
         public_key.verify(&msg, &self.signature)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,6 @@ pub use filter::Filter;
 
 mod manifest;
 pub use manifest::{Manifest, PublicKeyManifest};
+
+mod descriptor;
+pub use descriptor::{Descriptor, Edges};

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ pub struct Cli {
 
 #[derive(Debug, clap::Subcommand)]
 pub enum Cmd {
+    Descriptor(cmd::descriptor::Cmd),
     Filter(cmd::filter::Cmd),
     Key(cmd::key::Cmd),
     Manifest(cmd::manifest::Cmd),
@@ -23,6 +24,7 @@ fn main() -> Result {
 
 fn run(cli: Cli) -> Result {
     match cli.cmd {
+        Cmd::Descriptor(cmd) => cmd.run(),
         Cmd::Filter(cmd) => cmd.run(),
         Cmd::Key(cmd) => cmd.run(),
         Cmd::Manifest(cmd) => cmd.run(),


### PR DESCRIPTION
Since the CSV for a deny list is massive once edges are included this  PR

* Includes a `descriptor generate` command that generates a descriptor ison from a csv file
* Allows the csv file  to include both a target pub key (for edges) as well as a deny reason
* changes the filter and manifest commands to use the descriptor file instead of the csv