### PR TITLE
V2 filter version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ manifest.json
 *.bin
 *.key
 public_key.json
+descriptor.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anstream"
-version = "0.5.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -18,15 +18,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
 dependencies = [
  "utf8parse",
 ]
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "2.1.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.5"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824956d0dca8334758a5b7f7e50518d66ea319330cbceedcf76905c2f6ab30e3"
+checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.5"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122ec64120a49b4563ccaedcbea7818d069ed8e9aa6d829b82d8a4128936b2ab"
+checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
 dependencies = [
  "anstream",
  "anstyle",
@@ -464,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
 
 [[package]]
 name = "heck"
@@ -509,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -970,18 +970,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.48"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
+checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.48"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
+checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1157,7 +1157,8 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "sha2 0.9.9",
+ "sha2 0.10.8",
+ "thiserror",
  "twox-hash",
  "xorf",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-base64 = "0"
+base64 = ">=0.21"
 sha2 = "0"
 bytes = "*"
 clap = { version = "4", features = ["derive"] }
@@ -22,4 +22,5 @@ serde_json = "1"
 rand = "0.8"
 helium-crypto = { version = "0.8.0", features = ["multisig"] }
 anyhow = "1"
+thiserror = "1"
 indexmap = { version = "2", features = ["serde"] }

--- a/src/cmd/descriptor.rs
+++ b/src/cmd/descriptor.rs
@@ -1,10 +1,10 @@
 use crate::{
     cmd::{open_output_file, print_json},
-    Descriptor, Result,
+    Descriptor,
 };
+use anyhow::{Context, Result};
 use helium_crypto::PublicKey;
-use std::collections::HashMap;
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
 #[derive(clap::Args, Debug)]
 pub struct Cmd {
@@ -13,7 +13,7 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(&self) -> Result {
+    pub fn run(&self) -> Result<()> {
         self.cmd.run()
     }
 }
@@ -26,7 +26,7 @@ pub enum DescriptorCommand {
 }
 
 impl DescriptorCommand {
-    pub fn run(&self) -> Result {
+    pub fn run(&self) -> Result<()> {
         match self {
             Self::Generate(cmd) => cmd.run(),
             Self::CountEdges(cmd) => cmd.run(),
@@ -45,8 +45,9 @@ pub struct Generate {
 }
 
 impl Generate {
-    pub fn run(&self) -> Result {
-        let descriptor = Descriptor::from_csv(&self.input)?;
+    pub fn run(&self) -> Result<()> {
+        let descriptor = Descriptor::from_csv(&self.input)
+            .context(format!("reading descriptor {}", self.input.display()))?;
         let file = open_output_file(&self.output, false)?;
         serde_json::to_writer(file, &descriptor)?;
         Ok(())
@@ -64,8 +65,9 @@ pub struct CountEdges {
 }
 
 impl CountEdges {
-    pub fn run(&self) -> Result {
-        let descriptor = Descriptor::from_json(&self.input)?;
+    pub fn run(&self) -> Result<()> {
+        let descriptor = Descriptor::from_json(&self.input)
+            .context(format!("reading descriptor {}", self.input.display()))?;
         let mut counts: HashMap<&PublicKey, i32> = HashMap::new();
         for node in &descriptor.nodes {
             counts.insert(&node.key, -1); // -1 denotes all edges

--- a/src/cmd/filter.rs
+++ b/src/cmd/filter.rs
@@ -155,8 +155,8 @@ impl Info {
             .context(format!("reading filter {}", self.input.display()))?;
 
         let mut json = serde_json::to_value(&filter)?;
-        json["version"] = filter.version.into();
-        print_json(&filter)
+        json["fingerprints"] = filter.filter.len().into();
+        print_json(&json)
     }
 }
 

--- a/src/cmd/key.rs
+++ b/src/cmd/key.rs
@@ -1,4 +1,5 @@
-use crate::{cmd::print_json, manifest::PublicKeyManifest, Result};
+use crate::{cmd::print_json, manifest::PublicKeyManifest};
+use anyhow::{Context, Result};
 use serde_json::json;
 use std::path::PathBuf;
 
@@ -9,7 +10,7 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub fn run(&self) -> Result {
+    pub fn run(&self) -> Result<()> {
         self.cmd.run()
     }
 }
@@ -21,7 +22,7 @@ pub enum KeyCommand {
 }
 
 impl KeyCommand {
-    pub fn run(&self) -> Result {
+    pub fn run(&self) -> Result<()> {
         match self {
             Self::Info(cmd) => cmd.run(),
         }
@@ -37,13 +38,14 @@ pub struct Info {
 }
 
 impl Info {
-    pub fn run(&self) -> Result {
-        let manifest = PublicKeyManifest::from_path(&self.input)?;
+    pub fn run(&self) -> Result<()> {
+        let manifest = PublicKeyManifest::from_path(&self.input)
+            .context(format!("reading public key {}", self.input.display()))?;
         print_manifest(&manifest)
     }
 }
 
-fn print_manifest(manifest: &PublicKeyManifest) -> Result {
+fn print_manifest(manifest: &PublicKeyManifest) -> Result<()> {
     let json = json!({
         "address": manifest.public_key()?.to_string(),
         "keys": manifest.public_keys.len(),

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,4 +1,4 @@
-use std::{fs, io, path::Path};
+use std::{fs, path::Path};
 
 pub mod data;
 pub mod descriptor;
@@ -6,16 +6,18 @@ pub mod filter;
 pub mod key;
 pub mod manifest;
 
-pub fn print_json<T: ?Sized + serde::Serialize>(value: &T) -> crate::Result {
+pub fn print_json<T: ?Sized + serde::Serialize>(value: &T) -> anyhow::Result<()> {
     println!("{}", serde_json::to_string_pretty(value)?);
     Ok(())
 }
 
-pub fn open_output_file(filename: &Path, create_new: bool) -> io::Result<fs::File> {
+pub fn open_output_file(filename: &Path, create_new: bool) -> anyhow::Result<fs::File> {
+    use anyhow::Context;
     fs::OpenOptions::new()
         .write(true)
         .create(true)
         .create_new(create_new)
         .truncate(true)
         .open(filename)
+        .context(format!("opening output file {}", filename.display()))
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,25 +1,54 @@
-use crate::{Descriptor, Result};
+use crate::{base64_serde, Descriptor, Error, Result};
 use bytes::{Buf, BufMut, BytesMut};
 use helium_crypto::{PublicKey, Verify};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{fs::File, hash::Hasher, io::Read, path::Path};
 use twox_hash::XxHash64;
-use xorf::{Filter as XorFilter, Xor32};
+use xorf::{BinaryFuse32, Filter as _, Xor32};
 
-pub const VERSION: u8 = 1;
+pub const VERSION: u8 = 2;
 
 #[derive(Serialize)]
 pub struct Filter {
     pub(crate) version: u8,
+    #[serde(with = "base64_serde")]
     pub(crate) signature: Vec<u8>,
     pub(crate) serial: u32,
     #[serde(skip_serializing)]
-    pub(crate) filter: Xor32,
+    pub(crate) filter: FilterData,
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum FilterData {
+    V1(Xor32),
+    V2(BinaryFuse32),
+}
+
+impl From<Xor32> for FilterData {
+    fn from(filter: Xor32) -> Self {
+        Self::V1(filter)
+    }
+}
+
+impl From<BinaryFuse32> for FilterData {
+    fn from(filter: BinaryFuse32) -> Self {
+        Self::V2(filter)
+    }
+}
+
+impl FilterData {
+    pub fn contains(&self, hash: &u64) -> bool {
+        match self {
+            Self::V1(filter) => filter.contains(hash),
+            Self::V2(filter) => filter.contains(hash),
+        }
+    }
 }
 
 impl Filter {
-    pub fn new(serial: u32, filter: Xor32) -> Result<Self> {
+    pub fn new<F: Into<FilterData>>(serial: u32, filter: F) -> Result<Self> {
+        let filter = filter.into();
         Ok(Self {
             version: VERSION,
             serial,
@@ -40,8 +69,8 @@ impl Filter {
         }
         hashes.sort_unstable();
         hashes.dedup();
-        let xor_filter = Xor32::try_from(&hashes)?;
-        Filter::new(serial, xor_filter)
+        let filter = BinaryFuse32::try_from(&hashes).map_err(Error::filter)?;
+        Filter::new(serial, filter)
     }
 
     pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
@@ -64,7 +93,7 @@ impl Filter {
 
     pub fn hash(&self) -> Result<Vec<u8>> {
         let bytes = self.to_signing_bytes()?;
-        Ok(Sha256::digest(&bytes).to_vec())
+        Ok(Sha256::digest(bytes).to_vec())
     }
 
     pub fn contains(&self, public_key: &PublicKey) -> bool {
@@ -101,15 +130,22 @@ impl Filter {
         })
     }
 
-    pub fn from_bytes<D: AsRef<[u8]>>(data: D) -> Result<Self> {
-        let mut buf = data.as_ref();
+    pub fn from_bytes(data: &[u8]) -> Result<Self> {
+        let mut buf = data;
         let version = buf.get_u8();
         let signature_len = buf.get_u16_le() as usize;
         let signature = buf.copy_to_bytes(signature_len).to_vec();
         let serial = buf.get_u32_le();
-        let filter = bincode::deserialize(buf)?;
+        let filter: FilterData = match version {
+            1 => {
+                let filter: Xor32 = bincode::deserialize(buf)?;
+                filter.into()
+            }
+            2 => bincode::deserialize(buf)?,
+            _ => return Err(Error::filter("Unsupported filter version")),
+        };
         Ok(Self {
-            version,
+            version: VERSION,
             signature,
             serial,
             filter,

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -44,6 +44,13 @@ impl FilterData {
             Self::V2(filter) => filter.contains(hash),
         }
     }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Self::V1(filter) => filter.len(),
+            Self::V2(filter) => filter.len(),
+        }
+    }
 }
 
 impl Filter {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,30 @@
 pub mod cmd;
 
-pub type Result<T = ()> = anyhow::Result<T>;
-pub type Error = anyhow::Error;
+pub type Result<T = ()> = std::result::Result<T, Error>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("bincode: {0}")]
+    Bincode(#[from] Box<bincode::ErrorKind>),
+    #[error("json decode: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("csv decode: {0}")]
+    Csv(#[from] csv::Error),
+    #[error("base64 decode: {0}")]
+    Base64(#[from] base64::DecodeError),
+    #[error("crypto: {0}")]
+    Crypto(#[from] helium_crypto::Error),
+    #[error("filter: {0}")]
+    Filter(String),
+}
+
+impl Error {
+    pub fn filter(err: &str) -> Self {
+        Self::Filter(err.to_string())
+    }
+}
 
 mod filter;
 pub use filter::Filter;
@@ -11,3 +34,31 @@ pub use manifest::{Manifest, PublicKeyManifest};
 
 mod descriptor;
 pub use descriptor::{Descriptor, Edges};
+
+pub mod base64_serde {
+    use base64::{engine::general_purpose::STANDARD, Engine};
+    use serde::{de, Deserialize, Deserializer, Serializer};
+
+    pub fn deserialize<'de, D>(d: D) -> std::result::Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let sig_string = String::deserialize(d)?;
+        if sig_string.is_empty() {
+            return Ok(vec![]);
+        }
+        STANDARD
+            .decode(sig_string)
+            .map_err(|err| de::Error::custom(format!("invalid base64: \"{}\"", err)))
+    }
+
+    pub fn serialize<S>(data: &[u8], s: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if data.is_empty() {
+            return s.serialize_str("");
+        }
+        s.serialize_str(&STANDARD.encode(data))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
+use anyhow::Result;
 use clap::Parser;
-use xorf_generator::{cmd, Result};
+use xorf_generator::cmd;
 
 #[derive(Debug, Parser)]
 #[command(version = env!("CARGO_PKG_VERSION"))]
@@ -18,12 +19,12 @@ pub enum Cmd {
     Manifest(cmd::manifest::Cmd),
 }
 
-fn main() -> Result {
+fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     run(cli)
 }
 
-fn run(cli: Cli) -> Result {
+fn run(cli: Cli) -> Result<()> {
     match cli.cmd {
         Cmd::Data(cmd) => cmd.run(),
         Cmd::Descriptor(cmd) => cmd.run(),

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,4 +1,4 @@
-use crate::Result;
+use crate::{base64_serde, Result};
 use helium_crypto::{multihash, multisig, Network, PublicKey, Verify};
 use serde::{Deserialize, Serialize};
 use std::{fs::File, io::BufReader, ops::Deref, path::Path};
@@ -65,7 +65,7 @@ impl PublicKeyManifest {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct ManifestSignature {
     address: ManifestAddres,
-    #[serde(with = "base64")]
+    #[serde(with = "base64_serde")]
     signature: Vec<u8>,
 }
 
@@ -133,33 +133,5 @@ mod public_key {
         S: Serializer,
     {
         s.serialize_str(&public_key.to_string())
-    }
-}
-
-mod base64 {
-    use base64::{engine::general_purpose::STANDARD, Engine};
-    use serde::{de, Deserialize, Deserializer, Serializer};
-
-    pub fn deserialize<'de, D>(d: D) -> std::result::Result<Vec<u8>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let sig_string = String::deserialize(d)?;
-        if sig_string.is_empty() {
-            return Ok(vec![]);
-        }
-        STANDARD
-            .decode(sig_string)
-            .map_err(|err| de::Error::custom(format!("invalid base64: \"{}\"", err)))
-    }
-
-    pub fn serialize<S>(data: &[u8], s: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        if data.is_empty() {
-            return s.serialize_str("");
-        }
-        s.serialize_str(&STANDARD.encode(data))
     }
 }


### PR DESCRIPTION
* Adds ability to read the old version 1 filters
* Adds a version 2 read/write for BinaryFuse32 instead of Xor32
* Makes the library part of this app a library. i.e. use thiserror instead of anynow, and use anyhow only in the cli commands
* Add context to cli errors