### PR TITLE
Generate/use descriptor.bin.gz

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ $ xorf-generator descriptor generate -i hotspots.csv
 ```
 
 where the `hotspots.csv` is the list of public keys and edges to include in the
-filter. This generates a (large) `descriptor.bin` file with the list of public
-keys and edges.
+filter. This generates a (large) `descriptor.bin.gz` file with the list of
+public keys and edges.
 
 ### Generate Signing Data
 
@@ -80,7 +80,8 @@ The signing data is the data that is signed by each member of the multisig and u
 $ xorf-generator data generate --serial 1
 ```
 
-Generates a `data.bin` file from the (implied) `descriptor.bin` file with a given embedded serial number.
+Generates a `data.bin` file from the (implied) `descriptor.bin.gz` file with a
+given embedded serial number.
 
 ### Generate a Manifest
 
@@ -90,7 +91,7 @@ Generate a manifest for signing data and serial number:
 $ xorf-generator manifest generate -f
 ```
 
-which takes `descriptor.bin` and a serial number for the final filter. data.
+which takes `descriptor.bin.gz` and a serial number for the final filter. data.
 This will generate a `manifest.json` file with the hash of the signing data, the
 serial number and a signature array entry where multisig members will add
 signatures to. The `-f` option force overwrites an existing manifest output

--- a/src/cmd/data.rs
+++ b/src/cmd/data.rs
@@ -33,7 +33,7 @@ impl DataCommand {
 #[derive(Debug, clap::Args)]
 pub struct Generate {
     /// The input descriptor file to generate signing bytes for
-    #[arg(default_value = "descriptor.bin")]
+    #[arg(default_value = "descriptor.bin.gz")]
     input: PathBuf,
     /// The file to write the resulting signing bytes to
     #[arg(default_value = "data.bin")]

--- a/src/cmd/descriptor.rs
+++ b/src/cmd/descriptor.rs
@@ -43,7 +43,7 @@ pub struct Generate {
     /// The input csv file to generate a descriptor for
     input: PathBuf,
     /// The file to write the resulting descriptor file to
-    #[arg(default_value = "descriptor.bin")]
+    #[arg(default_value = "descriptor.bin.gz")]
     output: PathBuf,
 }
 
@@ -62,7 +62,7 @@ impl Generate {
 #[derive(Debug, clap::Args)]
 pub struct CountEdges {
     /// The input descriptor file to generate signing bytes for
-    #[arg(default_value = "descriptor.bin")]
+    #[arg(default_value = "descriptor.bin.gz")]
     input: PathBuf,
     /// The file to write the resulting edge counts to
     #[arg(default_value = "edge_counts.json")]
@@ -85,7 +85,7 @@ impl CountEdges {
 #[derive(clap::Args, Debug)]
 pub struct Find {
     /// The descriptor file to check for membership
-    #[arg(long, short, default_value = "descriptor.bin")]
+    #[arg(long, short, default_value = "descriptor.bin.gz")]
     input: PathBuf,
     /// The public key to check
     key: PublicKey,
@@ -113,7 +113,7 @@ impl Find {
 #[derive(clap::Args, Debug)]
 pub struct Info {
     /// The descriptor file to check for membership
-    #[arg(long, short, default_value = "descriptor.bin")]
+    #[arg(long, short, default_value = "descriptor.bin.gz")]
     input: PathBuf,
 }
 


### PR DESCRIPTION
Use descriptor.bin.gz to indicate the binary file is zipped.

Fixes #37 